### PR TITLE
Adds more Headers methods

### DIFF
--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -73,7 +73,9 @@ module Headers = {
 
   @new external empty: t = "Headers"
   @new external make: init => t = "Headers"
-  @new external clone: t => t = "Headers"
+  /**
+   * Non-standard
+   */ @new external clone: t => t = "Headers"
   @new external fromObject: {..} => t = "Headers"
   @new external fromArray: array<(string, string)> => t = "Headers"
 

--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -89,14 +89,9 @@ module Headers = {
   // The following are taken from the iterable protocol spec
 
   /**
-    * Callback arguments are (value, key)
-    */ @send
-  external forEach: (t, @uncurry (string, string) => unit) => unit = "forEach"
-
-  /**
     * Callback arguments are (value, key, headers)
     */ @send
-  external forEachWithHeaders: (t, @uncurry (string, string, t) => unit) => unit = "forEach"
+  external forEach: (t, @uncurry (string, string, t) => unit) => unit = "forEach"
 
   @send external entries: t => Js.Array.array_like<(string, string)> = "entries"
   @send external keys: t => Js.Array.array_like<string> = "keys"

--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -73,6 +73,7 @@ module Headers = {
 
   @new external empty: t = "Headers"
   @new external make: init => t = "Headers"
+  @new external clone: t => t = "Headers"
   @new external fromObject: {..} => t = "Headers"
   @new external fromArray: array<(string, string)> => t = "Headers"
 
@@ -82,6 +83,20 @@ module Headers = {
   external get: (t, string) => option<string> = "get"
   @send external has: (t, string) => bool = "has"
   @send external set: (t, string, string) => unit = "set"
+
+  /**
+    * Callback arguments are (value, key)
+    */ @send
+  external forEach: (t, @uncurry (string, string) => unit) => unit = "forEach"
+
+  /**
+    * Callback arguments are (value, key, headers)
+    */ @send
+  external forEachWithHeaders: (t, @uncurry (string, string, t) => unit) => unit = "forEach"
+
+  @send external entries: t => Js.Array2.array_like<(string, string)> = "entries"
+  @send external keys: t => Js.Array2.array_like<string> = "keys"
+  @send external values: t => Js.Array2.array_like<string> = "values"
 }
 
 module Request = {

--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -84,6 +84,8 @@ module Headers = {
   @send external has: (t, string) => bool = "has"
   @send external set: (t, string, string) => unit = "set"
 
+  // The following are taken from the iterable protocol spec
+
   /**
     * Callback arguments are (value, key)
     */ @send
@@ -94,9 +96,9 @@ module Headers = {
     */ @send
   external forEachWithHeaders: (t, @uncurry (string, string, t) => unit) => unit = "forEach"
 
-  @send external entries: t => Js.Array2.array_like<(string, string)> = "entries"
-  @send external keys: t => Js.Array2.array_like<string> = "keys"
-  @send external values: t => Js.Array2.array_like<string> = "values"
+  @send external entries: t => Js.Array.array_like<(string, string)> = "entries"
+  @send external keys: t => Js.Array.array_like<string> = "keys"
+  @send external values: t => Js.Array.array_like<string> = "values"
 }
 
 module Request = {


### PR DESCRIPTION
Happy to adjust however you'd like. I had these in bindings for my own headers module for another library and figured they could be useful here.

clone, for creating headers from headers

forEach / forEachWithHeaders

iterator methods:
entries
keys
values