### PR TITLE
activate reanalyze's exception analysis for async/await

### DIFF
--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -173,6 +173,6 @@ module Response = {
   // @send external arrayBuffer: t => Promise.t<arrayBuffer> = "arrayBuffer"
 }
 
-@val external fetch: (string, Request.init) => Promise.t<Response.t> = "fetch"
+@raises(JsError) @val external fetch: (string, Request.init) => Promise.t<Response.t> = "fetch"
 @val external get: string => Promise.t<Response.t> = "fetch"
 @val external send: Request.t => Promise.t<Response.t> = "fetch"


### PR DESCRIPTION
Adding this enables reanalyze to do exception analysis when using `rescript-fetch` with the upcoming async/await feature in ReScript v10.1.

The exception analysis in question is shown here: https://forum.rescript-lang.org/t/ann-async-await-is-coming-to-rescript/3488/16