### PR TITLE
AbortSignal bindings

### DIFF
--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -1,5 +1,6 @@
 module AbortController = Fetch_Abort.Controller
 module AbortSignal = Fetch_Abort.Signal
+module AbortEvent = Fetch_Abort.Event
 module Blob = Fetch_Blob
 module FormData = Fetch_FormData
 

--- a/src/Fetch_Abort.res
+++ b/src/Fetch_Abort.res
@@ -1,10 +1,54 @@
+module Event = {
+  type t
+}
+
 module Signal = {
   type t
 
+  /**
+  https://dom.spec.whatwg.org/#dom-abortsignal-any
+   */
+  @scope("AbortSignal")
+  external any: array<t> => t = "any"
+
+  /**
+  https://dom.spec.whatwg.org/#dom-abortsignal-timeout
+   */
+  @scope("AbortSignal")
+  external timeout: int => t = "timeout"
+
+  /**
+  https://dom.spec.whatwg.org/#dom-abortsignal-abort
+   */
+  @scope("AbortSignal")
+  external abort: (~reason: 'reason=?) => t = "abort"
+
   @get external aborted: t => bool = "aborted"
-  @get @return(nullable) external reason: t => option<_> = "aborted"
+  @get @return(nullable) external reason: t => option<'reason> = "aborted"
 
   @send external throwIfAborted: t => unit = "throwIfAborted"
+
+  @set external onabort: (t, Event.t => unit) => unit = "onabort"
+
+  // inherited from EventTarget
+  type addEventListenerOptions = {
+    capture?: bool,
+    once?: bool,
+    passive?: bool,
+    signal?: t,
+  }
+
+  @send
+  external addEventListener: (t, @string [#abort(Event.t => unit)], ~options: addEventListenerOptions=?) => unit =
+    "addEventListener"
+
+  type removeEventListenerOptions = {
+    capture?: bool,
+  }
+
+  @send
+  external removeEventListener: (t, @string [#abort(Event.t => unit)], ~options: removeEventListenerOptions=?) => unit =
+    "removeEventListener"
 }
 
 module Controller = {
@@ -14,5 +58,5 @@ module Controller = {
 
   @get external signal: t => Signal.t = "signal"
 
-  @send external abort: (t, 'reason) => unit = "abort"
+  @send external abort: (t, ~reason: 'reason=?) => unit = "abort"
 }


### PR DESCRIPTION
Adds the static constructors:
- AbortSignal.any
- AbortSignal.timeout
- AbortSignal.abort

And the EventTarget `addEventListener` / `removeEventListener` functions.

IMO these are probably not useful to bind in a very js-like way and it opens up a bit more API surface with the AbortEvent and so forth. I am struggling to imagine a usecase for not using `{ once: true }` on `addEventListener`, and the `abort` event is the only one that's useful, so it could be bound like:

```rescript
@send
external addAbortEventListener: (t, @as("abort") _, unit => unit, @as(json`{once:true}`)) => unit =
    "addEventListener"
```

In either event, what's your opinion on it?