### PR TITLE
chore: upgrade to ReScript 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ lib/bs
 .bsb.lock
 /node_modules/
 *.bs.js
+*.res.js
+/lib/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ let postBanana = async data => {
     "/api/bananas",
     {
       method: #POST,
-      body: data->Js.Json.stringifyAny->Belt.Option.getExn->Body.string,
+      body: data->JSON.stringifyAny->Option.getOrThrow->Body.string,
       headers: Headers.fromObject({
         "Content-type": "application/json",
       }),
@@ -36,11 +36,11 @@ See [examples](https://github.com/glennsl/rescript-fetch/blob/master/examples/) 
 npm install --save @glennsl/rescript-fetch
 ```
 
-Then add `@glennsl/rescript-fetch` to `bs-dependencies` in your `bsconfig.json`:
+Then add `@glennsl/rescript-fetch` to `dependencies` in your `rescript.json`:
 
 ```diff
  {
-   "bs-dependencies": [
+   "dependencies": [
 +    "@glennsl/rescript-fetch"
    ]
  }
@@ -56,6 +56,12 @@ For the moment, please see the interface file:
 
 
 ## Changes
+
+### 0.3.0
+
+* [BREAKING] Updated required minimum version of rescript to 12.
+* Replaced `bsconfig.json` with `rescript.json` and switched module spec to `esmodule`.
+* Migrated from `Js.Json.t`/`Js.Array.array_like` to the rescript 12 standard library (`JSON.t`, `Iterator.t`).
 
 ### 0.2.3
 

--- a/examples/example.res
+++ b/examples/example.res
@@ -13,7 +13,7 @@ let postJson = () => {
       "/api/bananas",
       {
         method: #POST,
-        body: data->Js.Json.stringifyAny->Belt.Option.getExn->Body.string,
+        body: data->JSON.stringifyAny->Option.getOrThrow->Body.string,
         headers: Headers.fromObject({
           "Content-type": "application/json",
         }),
@@ -24,7 +24,7 @@ let postJson = () => {
   }
 
   postBanana({
-    "sampledAt": Js.Date.now(),
+    "sampledAt": Date.now(),
     "cultivar": "Cavendish",
     "bunches": 10,
     "fruitsPerBunch": 20,
@@ -60,8 +60,8 @@ let abortFetch = async () => {
   let controller = AbortController.make()
   let timeoutSignal = AbortSignal.timeout(60_000)
   let manualSignal = AbortController.signal(controller)
-  let timeoutHandler = _ => Js.log("Request timed out after 60s")
-  let manualHandler = _ => Js.log("Request aborted manually")
+  let timeoutHandler = _ => Console.log("Request timed out after 60s")
+  let manualHandler = _ => Console.log("Request aborted manually")
   let signal = AbortSignal.any([timeoutSignal, manualSignal])
 
   AbortSignal.addEventListener(timeoutSignal, #abort(timeoutHandler), ~options={once: true, signal})
@@ -69,7 +69,7 @@ let abortFetch = async () => {
 
   let responsePromise = fetch("/api/long", {Request.signal: signal})
 
-  let _ = Js.Global.setTimeout(() => {
+  let _ = setTimeout(() => {
     AbortController.abort(controller, ~reason="User aborted")
   }, 1000)
 
@@ -77,6 +77,6 @@ let abortFetch = async () => {
     let _ = await responsePromise
     timeoutSignal->AbortSignal.removeEventListener(#abort(timeoutHandler), ~options=?None)
   } catch {
-  | Js.Exn.Error(error) => Js.Exn.message(error)->Js.log
+  | JsExn(error) => Console.log(JsExn.message(error))
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,146 @@
 {
   "name": "@glennsl/rescript-fetch",
-  "version": "0.2.3",
-  "lockfileVersion": 2,
+  "version": "0.3.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@glennsl/rescript-fetch",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
-        "rescript": "^10.1.2"
+        "rescript": "^12.2.0"
+      }
+    },
+    "node_modules/@rescript/darwin-arm64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.2.0.tgz",
+      "integrity": "sha512-xc3K/J7Ujl1vPiFY2009mRf3kWRlUe/VZyJWprseKxlcEtUQv89ter7r6pY+YFbtYvA/fcaEncL9CVGEdattAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/darwin-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-12.2.0.tgz",
+      "integrity": "sha512-qqcTvnlSeoKkywLjG7cXfYvKZ1e4Gz2kUKcD6SiqDgCqm8TF+spwlFAiM6sloRUOFsc0bpC/0R0B3yr01FCB1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/linux-arm64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-12.2.0.tgz",
+      "integrity": "sha512-ODmpG3ji+Nj/8d5yvXkeHlfKkmbw1Q4t1iIjVuNwtmFpz7TiEa7n/sQqoYdE+WzbDX3DoJfmJNbp3Ob7qCUoOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/linux-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-12.2.0.tgz",
+      "integrity": "sha512-2W9Y9/g19Y4F/subl8yV3T8QBG2oRaP+HciNRcBjptyEdw9LmCKH8+rhWO6sp3E+nZLwoE2IAkwH0WKV3wqlxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/runtime": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.2.0.tgz",
+      "integrity": "sha512-NwfljDRq1rjFPHUaca1nzFz13xsa9ZGkBkLvMhvVgavJT5+A4rMcLu8XAaVTi/oAhO/tlHf9ZDoOTF1AfyAk9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rescript/win32-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-12.2.0.tgz",
+      "integrity": "sha512-fhf8CBj3p1lkIXPeNko3mVTKQfXXm4BoxJtR1xAXxUn43wDpd8Lox4w8/EPBbbW6C/YFQW6H7rtpY+2AKuNaDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
       }
     },
     "node_modules/rescript": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.2.tgz",
-      "integrity": "sha512-PPdhOiN+lwqxQ0qvzHc1KW0TL12LDy2X+qo/JIMIP3bMfiH0vxQH2e/lXuoutWWm04fGQGTv3hWH+gKW3/UyfA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.2.0.tgz",
+      "integrity": "sha512-1Jf2cmNhyx5Mj2vwZ4XXPcXvNSjGj9D1jPBUcoqIOqRpLPo1ch2Ta/7eWh23xAHWHK5ow7BCDyYFjvZSjyjLzg==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "workspaces": [
+        "packages/playground",
+        "packages/@rescript/*",
+        "tests/dependencies/**",
+        "tests/analysis_tests/**",
+        "tests/docstring_tests",
+        "tests/gentype_tests/**",
+        "tests/tools_tests",
+        "tests/commonjs_tests",
+        "scripts/res"
+      ],
+      "dependencies": {
+        "@rescript/runtime": "12.2.0"
+      },
       "bin": {
-        "bsc": "bsc",
-        "bsrefmt": "bsrefmt",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
+        "bsc": "cli/bsc.js",
+        "bstracing": "cli/bstracing.js",
+        "rescript": "cli/rescript.js",
+        "rescript-legacy": "cli/rescript-legacy.js",
+        "rescript-tools": "cli/rescript-tools.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "optionalDependencies": {
+        "@rescript/darwin-arm64": "12.2.0",
+        "@rescript/darwin-x64": "12.2.0",
+        "@rescript/linux-arm64": "12.2.0",
+        "@rescript/linux-x64": "12.2.0",
+        "@rescript/win32-x64": "12.2.0"
       }
-    }
-  },
-  "dependencies": {
-    "rescript": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.2.tgz",
-      "integrity": "sha512-PPdhOiN+lwqxQ0qvzHc1KW0TL12LDy2X+qo/JIMIP3bMfiH0vxQH2e/lXuoutWWm04fGQGTv3hWH+gKW3/UyfA==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glennsl/rescript-fetch",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Zero-cost rescript bindings to the WHATWG Fetch API",
   "scripts": {
     "start": "rescript build -w",
@@ -23,9 +23,9 @@
   "homepage": "https://github.com/glennsl/rescript-fetch#readme",
   "files": [
     "src/*.res*",
-    "bsconfig.json"
+    "rescript.json"
   ],
   "devDependencies": {
-    "rescript": "^10.1.2"
+    "rescript": "^12.2.0"
   }
 }

--- a/rescript.json
+++ b/rescript.json
@@ -8,8 +8,8 @@
     { "dir": "examples", "type": "dev" }
   ],
   "package-specs": {
-    "module": "es6",
+    "module": "esmodule",
     "in-source": true
   },
-  "suffix": ".bs.js"
+  "suffix": ".res.js"
 }

--- a/src/Fetch.res
+++ b/src/Fetch.res
@@ -93,11 +93,11 @@ module Headers = {
   /**
     * Callback arguments are (value, key, headers)
     */ @send
-  external forEach: (t, @uncurry (string, string, t) => unit) => unit = "forEach"
+  external forEach: (t, (string, string, t) => unit) => unit = "forEach"
 
-  @send external entries: t => Js.Array.array_like<(string, string)> = "entries"
-  @send external keys: t => Js.Array.array_like<string> = "keys"
-  @send external values: t => Js.Array.array_like<string> = "values"
+  @send external entries: t => Iterator.t<(string, string)> = "entries"
+  @send external keys: t => Iterator.t<string> = "keys"
+  @send external values: t => Iterator.t<string> = "values"
 }
 
 module Request = {
@@ -145,7 +145,7 @@ module Request = {
   // @get external body: t => readableStream = "body"
   @get external bodyUsed: t => bool = "bodyUsed"
   @send external text: t => promise<string> = "text"
-  @send external json: t => promise<Js.Json.t> = "json"
+  @send external json: t => promise<JSON.t> = "json"
   @send external blob: t => promise<Blob.t> = "blob"
   @send external formData: t => promise<FormData.t> = "formData"
   // @send external arrayBuffer: t => promise<arrayBuffer> = "arrayBuffer"
@@ -169,7 +169,7 @@ module Response = {
   // @get external body: t => readableStream = "body"
   @get external bodyUsed: t => bool = "bodyUsed"
   @send external text: t => promise<string> = "text"
-  @send external json: t => promise<Js.Json.t> = "json"
+  @send external json: t => promise<JSON.t> = "json"
   @send external blob: t => promise<Blob.t> = "blob"
   @send external formData: t => promise<FormData.t> = "formData"
   // @send external arrayBuffer: t => promise<arrayBuffer> = "arrayBuffer"

--- a/src/Fetch_FormData.res
+++ b/src/Fetch_FormData.res
@@ -4,10 +4,9 @@ module EntryValue = {
   type t
 
   let classify = value =>
-    if Js.typeof(value) == "string" {
-      #String(Obj.magic(value))
-    } else {
-      assert false
+    switch Type.typeof(value) {
+    | #string => #String(Obj.magic(value))
+    | _ => assert(false)
     }
 }
 


### PR DESCRIPTION
Hey @glennsl,

I often use your lib as a dependency in projects. Thought I would just offer a PR to upgrade to ReScript 12 to help with consumers using newer res versions.

* Bump rescript dev dependency to ^12.2.0.
* Replace deprecated bsconfig.json with rescript.json and switch package-spec module from "es6" to "esmodule".
* Set output suffix to .res.js (the v11+ default) and update .gitignore accordingly.
* Migrate sources off deprecated v10 APIs:
  - Js.Json.t -> JSON.t
  - Js.Array.array_like -> Iterator.t (Headers entries/keys/values)
  - Js.typeof -> Type.typeof (typed polymorphic variant)
  - drop @uncurry on Headers.forEach (uncurried mode is the default).
* Update example.res and README to use the rescript 12 stdlib (JSON.stringifyAny, Option.getOrThrow, Date.now, setTimeout, Console.log, JsExn) and document rescript.json/dependencies.